### PR TITLE
Value Tag Compatibility - Documented & Tested!

### DIFF
--- a/influx/__init__.py
+++ b/influx/__init__.py
@@ -450,6 +450,23 @@ class InfluxDB:
             (optional)
 
         """
+        # start new
+        value_tags = {}
+        for tag, value in list(tags.items()):
+            if value == 'VALUE':
+                value_tags.add(tag)
+                del tags[tag]
+
+        '''
+        tags_index = {}
+
+        for i in range(len(fields)):
+            column = fields[i]
+            if column in value_tags:
+                tags_index[i] = column
+        '''
+        # end new
+
         points = []
         for line in values:
             line = dict(zip(fields, line))
@@ -457,6 +474,14 @@ class InfluxDB:
                     'measurement': measurement,
                     'fields': line,
                     }
+
+            # start new
+            point_tags = {}
+            for tag_key, tag_value in value_tags.items():
+                point_tags[tag_key] = line.pop(tag_key)
+            point['tags'] = point_tags
+            # end new
+
             if time_field and line.get(time_field, None):
                 point['time'] = line.pop(time_field)
             points.append(point)

--- a/influx/__init__.py
+++ b/influx/__init__.py
@@ -425,13 +425,29 @@ class InfluxDB:
         if time is None:
             time = pytool.time.utcnow()
 
-        lines = line_protocol.make_lines({
-                'tags': tags,
-                'points': [{
+        # Create list of value tags
+        value_tags = []
+        for tag, value in list(tags.items()):
+            if value == 'VALUE':
+                value_tags.append(tag)
+                del tags[tag]
+
+        # Create a point dict so value tags can be popped and replaced as tags
+        point = {
                     'measurement': measurement,
                     'fields': fields,
                     'time': time,
-                    }]
+                }
+
+        # Create a dict of value tags for each point and add as tags
+        point_tags = {}
+        for tag_key in value_tags:
+            point_tags[tag_key] = fields.pop(tag_key)
+        point['tags'] = point_tags
+
+        lines = line_protocol.make_lines({
+                'tags': tags,
+                'points': [point]
                 },
                 precision=precision)
         return lines

--- a/influx/__init__.py
+++ b/influx/__init__.py
@@ -450,22 +450,12 @@ class InfluxDB:
             (optional)
 
         """
-        # start new
+        # Create list of value tags
         value_tags = []
         for tag, value in list(tags.items()):
             if value == 'VALUE':
                 value_tags.append(tag)
                 del tags[tag]
-
-        '''
-        tags_index = {}
-
-        for i in range(len(fields)):
-            column = fields[i]
-            if column in value_tags:
-                tags_index[i] = column
-        '''
-        # end new
 
         points = []
         for line in values:
@@ -475,12 +465,11 @@ class InfluxDB:
                     'fields': line,
                     }
 
-            # start new
+            # Create a dict of value tags for each point and add as tags
             point_tags = {}
             for tag_key in value_tags:
                 point_tags[tag_key] = line.pop(tag_key)
             point['tags'] = point_tags
-            # end new
 
             if time_field and line.get(time_field, None):
                 point['time'] = line.pop(time_field)

--- a/influx/__init__.py
+++ b/influx/__init__.py
@@ -451,10 +451,10 @@ class InfluxDB:
 
         """
         # start new
-        value_tags = {}
+        value_tags = []
         for tag, value in list(tags.items()):
             if value == 'VALUE':
-                value_tags.add(tag)
+                value_tags.append(tag)
                 del tags[tag]
 
         '''
@@ -477,7 +477,7 @@ class InfluxDB:
 
             # start new
             point_tags = {}
-            for tag_key, tag_value in value_tags.items():
+            for tag_key in value_tags:
                 point_tags[tag_key] = line.pop(tag_key)
             point['tags'] = point_tags
             # end new

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -82,7 +82,7 @@ def test_make_many_lines():
     eq_(lines, expected)
 
 
-def test_make_many_lines_with_value_tag( ):
+def test_make_many_lines_with_value_tag():
     _make_many_lines = influx.InfluxDB._make_many_lines
 
     measurement = 'test_many'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -82,7 +82,7 @@ def test_make_many_lines():
     eq_(lines, expected)
 
 
-def test_make_many_lines_with_value_tag():
+def test_make_many_lines_with_value_tag( ):
     _make_many_lines = influx.InfluxDB._make_many_lines
 
     measurement = 'test_many'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -47,6 +47,16 @@ def test_make_lines():
         '1521241703097608192\n')
 
 
+def test_make_lines_with_value_tag():
+    _make_lines = influx.InfluxDB._make_lines
+    lines = _make_lines('test_measurement', {'tag2': 1.0, 'field': 2},
+                        {'tag1': 'test_tag', 'tag2': 'VALUE'},
+                        1521241703.097608192)
+
+    eq_(lines, 'test_measurement,tag1=test_tag,tag2=1.0 field=2 '
+        '1521241703097608192\n')
+
+
 def test_make_many_lines():
     _make_many_lines = influx.InfluxDB._make_many_lines
 
@@ -67,6 +77,31 @@ def test_make_many_lines():
             'test_many,tag_many=all alpha=2,beta=4,ts=2000\n'
             'test_many,tag_many=all alpha=3,beta=6,ts=3000\n'
             'test_many,tag_many=all alpha=4,beta=8,ts=4000\n'
+            )
+
+    eq_(lines, expected)
+
+
+def test_make_many_lines_with_value_tag():
+    _make_many_lines = influx.InfluxDB._make_many_lines
+
+    measurement = 'test_many'
+    fields = ['alpha', 'beta', 'ts']
+    values = [
+            [1, 2, 1000],
+            [2, 4, 2000],
+            [3, 6, 3000],
+            [4, 8, 4000],
+            ]
+    tags = {'tag_many': 'all', 'alpha': 'VALUE'}
+
+    lines = _make_many_lines(measurement, fields, values, tags)
+
+    expected = (
+            'test_many,alpha=1,tag_many=all beta=2,ts=1000\n'
+            'test_many,alpha=2,tag_many=all beta=4,ts=2000\n'
+            'test_many,alpha=3,tag_many=all beta=6,ts=3000\n'
+            'test_many,alpha=4,tag_many=all beta=8,ts=4000\n'
             )
 
     eq_(lines, expected)


### PR DESCRIPTION
Allows user to specify tag columns by including the argument tags={'[column_name]': 'VALUE', ...}